### PR TITLE
Update Settings.php

### DIFF
--- a/models/Settings.php
+++ b/models/Settings.php
@@ -2,7 +2,7 @@
 
 namespace Igniter\Broadcast\Models;
 
-use Igniter\Flame\Database\Model;
+use Model;
 use System\Classes\ExtensionManager;
 
 class Settings extends Model


### PR DESCRIPTION
I can see that this was changed recently. 

Using the path use Igniter\Flame\Database\Model;  resulted in on the front-end. 
Argument 1 passed to System\Actions\SettingsModel::__construct() must be an instance of Model, instance of Igniter\Broadcast\Models\Settings given, called in /home/site/public_html/vendor/tastyigniter/flame/src/Traits/ExtendableTrait.php on line 143

Using 
use Model; 
resolved the issue